### PR TITLE
Update the location FSH to have telecom-related invariants

### DIFF
--- a/input/fsh/vaccine_location.fsh
+++ b/input/fsh/vaccine_location.fsh
@@ -11,8 +11,26 @@ Id: vaccine-location
 * address only VaccineAddress
 * identifier.system 1..1
 * identifier.value 1..1
+* obeys vaccine-location-1
+* obeys vaccine-location-2
+* obeys vaccine-location-3
 
 ValueSet: SMARTTelecomSystem
 Id: smart-telecom-system
 * include CPS#phone
 * include CPS#url
+
+Invariant: vaccine-location-1
+Description: "Location should have a phone and an email"
+Severity: #warning
+Expression: "telecom.where(system = 'phone').exists() and telecom.where(system = 'url').exists()"
+
+Invariant: vaccine-location-2
+Description: "If a telecom claims to be a phone number, it should only have phone-like characters"
+Severity: #error
+Expression: "telecom.where(system = 'phone' and value.contains('@')).empty()"
+
+Invariant: vaccine-location-3
+Description: "If a telecom claims to be a URL, it should only have url-like characters"
+Severity: #error
+Expression: "telecom.where(system = 'url').exists() implies telecom.where(system = 'url' and value.matches('\\S')).exists()"

--- a/input/fsh/vaccine_location.fsh
+++ b/input/fsh/vaccine_location.fsh
@@ -14,6 +14,12 @@ Id: vaccine-location
 * obeys vaccine-location-1
 * obeys vaccine-location-2
 * obeys vaccine-location-3
+* identifier ^slicing.discriminator.type = #value
+* identifier ^slicing.discriminator.path = "system"
+* identifier ^slicing.rules = #open
+* identifier ^slicing.description = "Identifier needs at least one VTrckS value"
+* identifier contains vTrckS 1..1 MS
+* identifier[vTrckS].system = "https://cdc.gov/vaccines/programs/vtrcks"
 
 ValueSet: SMARTTelecomSystem
 Id: smart-telecom-system

--- a/input/fsh/vaccine_slot.fsh
+++ b/input/fsh/vaccine_slot.fsh
@@ -11,6 +11,9 @@ Id: vaccine-slot
     $BookingDeepLink named booking-link 0..1 MS and
     $BookingPhone named booking-phone 0..1 MS and
     $BookingCapacity named capacity 0..1 MS
+* obeys vaccine-slot-1
+* obeys vaccine-slot-2
+* obeys vaccine-slot-3
 
 ValueSet: VaccineSlotStatus
 Id: vaccine-slot-status
@@ -28,3 +31,19 @@ Id: booking-phone
 Extension: BookingCapacity
 Id: slot-capacity
 * value[x] only integer
+
+Invariant: vaccine-slot-1
+Description: "Slot should have a booking link"
+Severity: #warning
+Expression: "extension.where(url = 'http://fhir-registry.smarthealthit.org/StructureDefinition/booking-deep-link').exists()"
+
+Invariant: vaccine-slot-2
+Description: "Slot should have a booking phone number"
+Severity: #warning
+Expression: "extension.where(url = 'http://fhir-registry.smarthealthit.org/StructureDefinition/booking-phone').exists()"
+
+// NOTE: this constraint should, at some point, exclude short slot times (less than an hour) but doesn't now due to FHIRPath limitations
+Invariant: vaccine-slot-3
+Description: "Slot should have a capacity if the time frames are longer than an hour"
+Severity: #warning
+Expression: "extension.where(url = 'http://fhir-registry.smarthealthit.org/StructureDefinition/slot-capacity').exists()"

--- a/resources/StructureDefinition-vaccine-location.json
+++ b/resources/StructureDefinition-vaccine-location.json
@@ -450,10 +450,20 @@
       {
         "id": "Location.identifier",
         "path": "Location.identifier",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "system"
+            }
+          ],
+          "rules": "open",
+          "description": "Identifier needs at least one VTrckS value"
+        },
         "short": "Unique code or number identifying the location to its users",
         "definition": "Unique code or number identifying the location to its users.",
         "requirements": "Organization label locations in registries, need to keep track of those.",
-        "min": 0,
+        "min": 1,
         "max": "*",
         "base": {
           "path": "Location.identifier",
@@ -842,6 +852,450 @@
       },
       {
         "id": "Location.identifier.assigner",
+        "path": "Location.identifier.assigner",
+        "short": "Organization that issued id (may be just text)",
+        "definition": "Organization that issued/manages the identifier.",
+        "comment": "The Identifier.assigner may omit the .reference element and only contain a .display element reflecting the name or other textual information about the assigning organization.",
+        "min": 0,
+        "max": "1",
+        "base": {
+          "path": "Identifier.assigner",
+          "min": 0,
+          "max": "1"
+        },
+        "type": [
+          {
+            "code": "Reference",
+            "targetProfile": [
+              "http://hl7.org/fhir/StructureDefinition/Organization"
+            ]
+          }
+        ],
+        "constraint": [
+          {
+            "key": "ele-1",
+            "severity": "error",
+            "human": "All FHIR elements must have a @value or children",
+            "expression": "hasValue() or (children().count() > id.count())",
+            "xpath": "@value|f:*|h:div",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element"
+          }
+        ],
+        "isModifier": false,
+        "isSummary": true,
+        "mapping": [
+          {
+            "identity": "v2",
+            "map": "CX.4 / (CX.4,CX.9,CX.10)"
+          },
+          {
+            "identity": "rim",
+            "map": "II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper"
+          },
+          {
+            "identity": "servd",
+            "map": "./IdentifierIssuingAuthority"
+          }
+        ]
+      },
+      {
+        "id": "Location.identifier:vTrckS",
+        "path": "Location.identifier",
+        "sliceName": "vTrckS",
+        "short": "Unique code or number identifying the location to its users",
+        "definition": "Unique code or number identifying the location to its users.",
+        "requirements": "Organization label locations in registries, need to keep track of those.",
+        "min": 1,
+        "max": "1",
+        "base": {
+          "path": "Location.identifier",
+          "min": 0,
+          "max": "*"
+        },
+        "type": [
+          {
+            "code": "Identifier"
+          }
+        ],
+        "constraint": [
+          {
+            "key": "ele-1",
+            "severity": "error",
+            "human": "All FHIR elements must have a @value or children",
+            "expression": "hasValue() or (children().count() > id.count())",
+            "xpath": "@value|f:*|h:div",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element"
+          }
+        ],
+        "mustSupport": true,
+        "isModifier": false,
+        "isSummary": true,
+        "mapping": [
+          {
+            "identity": "w5",
+            "map": "FiveWs.identifier"
+          },
+          {
+            "identity": "rim",
+            "map": ".id"
+          }
+        ]
+      },
+      {
+        "id": "Location.identifier:vTrckS.id",
+        "path": "Location.identifier.id",
+        "representation": [
+          "xmlAttr"
+        ],
+        "short": "Unique id for inter-element referencing",
+        "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+        "min": 0,
+        "max": "1",
+        "base": {
+          "path": "Element.id",
+          "min": 0,
+          "max": "1"
+        },
+        "type": [
+          {
+            "code": "http://hl7.org/fhirpath/System.String",
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                "valueUrl": "string"
+              }
+            ]
+          }
+        ],
+        "isModifier": false,
+        "isSummary": false,
+        "mapping": [
+          {
+            "identity": "rim",
+            "map": "n/a"
+          }
+        ]
+      },
+      {
+        "id": "Location.identifier:vTrckS.extension",
+        "path": "Location.identifier.extension",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "url"
+            }
+          ],
+          "description": "Extensions are always sliced by (at least) url",
+          "rules": "open"
+        },
+        "short": "Additional content defined by implementations",
+        "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+        "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+        "alias": [
+          "extensions",
+          "user content"
+        ],
+        "min": 0,
+        "max": "*",
+        "base": {
+          "path": "Element.extension",
+          "min": 0,
+          "max": "*"
+        },
+        "type": [
+          {
+            "code": "Extension"
+          }
+        ],
+        "constraint": [
+          {
+            "key": "ele-1",
+            "severity": "error",
+            "human": "All FHIR elements must have a @value or children",
+            "expression": "hasValue() or (children().count() > id.count())",
+            "xpath": "@value|f:*|h:div",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element"
+          },
+          {
+            "key": "ext-1",
+            "severity": "error",
+            "human": "Must have either extensions or value[x], not both",
+            "expression": "extension.exists() != value.exists()",
+            "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+            "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+          }
+        ],
+        "isModifier": false,
+        "isSummary": false,
+        "mapping": [
+          {
+            "identity": "rim",
+            "map": "n/a"
+          }
+        ]
+      },
+      {
+        "id": "Location.identifier:vTrckS.use",
+        "path": "Location.identifier.use",
+        "short": "usual | official | temp | secondary | old (If known)",
+        "definition": "The purpose of this identifier.",
+        "comment": "Applications can assume that an identifier is permanent unless it explicitly says that it is temporary.",
+        "requirements": "Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers.",
+        "min": 0,
+        "max": "1",
+        "base": {
+          "path": "Identifier.use",
+          "min": 0,
+          "max": "1"
+        },
+        "type": [
+          {
+            "code": "code"
+          }
+        ],
+        "constraint": [
+          {
+            "key": "ele-1",
+            "severity": "error",
+            "human": "All FHIR elements must have a @value or children",
+            "expression": "hasValue() or (children().count() > id.count())",
+            "xpath": "@value|f:*|h:div",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element"
+          }
+        ],
+        "isModifier": true,
+        "isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary id for a permanent one.",
+        "isSummary": true,
+        "binding": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+              "valueString": "IdentifierUse"
+            }
+          ],
+          "strength": "required",
+          "description": "Identifies the purpose for this identifier, if known .",
+          "valueSet": "http://hl7.org/fhir/ValueSet/identifier-use|4.0.1"
+        },
+        "mapping": [
+          {
+            "identity": "v2",
+            "map": "N/A"
+          },
+          {
+            "identity": "rim",
+            "map": "Role.code or implied by context"
+          }
+        ]
+      },
+      {
+        "id": "Location.identifier:vTrckS.type",
+        "path": "Location.identifier.type",
+        "short": "Description of identifier",
+        "definition": "A coded type for the identifier that can be used to determine which identifier to use for a specific purpose.",
+        "comment": "This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage.   Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type.",
+        "requirements": "Allows users to make use of identifiers when the identifier system is not known.",
+        "min": 0,
+        "max": "1",
+        "base": {
+          "path": "Identifier.type",
+          "min": 0,
+          "max": "1"
+        },
+        "type": [
+          {
+            "code": "CodeableConcept"
+          }
+        ],
+        "constraint": [
+          {
+            "key": "ele-1",
+            "severity": "error",
+            "human": "All FHIR elements must have a @value or children",
+            "expression": "hasValue() or (children().count() > id.count())",
+            "xpath": "@value|f:*|h:div",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element"
+          }
+        ],
+        "isModifier": false,
+        "isSummary": true,
+        "binding": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+              "valueString": "IdentifierType"
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+              "valueBoolean": true
+            }
+          ],
+          "strength": "extensible",
+          "description": "A coded type for an identifier that can be used to determine which identifier to use for a specific purpose.",
+          "valueSet": "http://hl7.org/fhir/ValueSet/identifier-type"
+        },
+        "mapping": [
+          {
+            "identity": "v2",
+            "map": "CX.5"
+          },
+          {
+            "identity": "rim",
+            "map": "Role.code or implied by context"
+          }
+        ]
+      },
+      {
+        "id": "Location.identifier:vTrckS.system",
+        "path": "Location.identifier.system",
+        "short": "The namespace for the identifier value",
+        "definition": "Establishes the namespace for the value - that is, a URL that describes a set values that are unique.",
+        "comment": "Identifier.system is always case sensitive.",
+        "requirements": "There are many sets  of identifiers.  To perform matching of two identifiers, we need to know what set we're dealing with. The system identifies a particular set of unique identifiers.",
+        "min": 1,
+        "max": "1",
+        "base": {
+          "path": "Identifier.system",
+          "min": 0,
+          "max": "1"
+        },
+        "type": [
+          {
+            "code": "uri"
+          }
+        ],
+        "patternUri": "https://cdc.gov/vaccines/programs/vtrcks",
+        "example": [
+          {
+            "label": "General",
+            "valueUri": "http://www.acme.com/identifiers/patient"
+          }
+        ],
+        "constraint": [
+          {
+            "key": "ele-1",
+            "severity": "error",
+            "human": "All FHIR elements must have a @value or children",
+            "expression": "hasValue() or (children().count() > id.count())",
+            "xpath": "@value|f:*|h:div",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element"
+          }
+        ],
+        "isModifier": false,
+        "isSummary": true,
+        "mapping": [
+          {
+            "identity": "v2",
+            "map": "CX.4 / EI-2-4"
+          },
+          {
+            "identity": "rim",
+            "map": "II.root or Role.id.root"
+          },
+          {
+            "identity": "servd",
+            "map": "./IdentifierType"
+          }
+        ]
+      },
+      {
+        "id": "Location.identifier:vTrckS.value",
+        "path": "Location.identifier.value",
+        "short": "The value that is unique",
+        "definition": "The portion of the identifier typically relevant to the user and which is unique within the context of the system.",
+        "comment": "If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986.  The value's primary purpose is computational mapping.  As a result, it may be normalized for comparison purposes (e.g. removing non-significant whitespace, dashes, etc.)  A value formatted for human display can be conveyed using the [Rendered Value extension](extension-rendered-value.html). Identifier.value is to be treated as case sensitive unless knowledge of the Identifier.system allows the processer to be confident that non-case-sensitive processing is safe.",
+        "min": 1,
+        "max": "1",
+        "base": {
+          "path": "Identifier.value",
+          "min": 0,
+          "max": "1"
+        },
+        "type": [
+          {
+            "code": "string"
+          }
+        ],
+        "example": [
+          {
+            "label": "General",
+            "valueString": "123456"
+          }
+        ],
+        "constraint": [
+          {
+            "key": "ele-1",
+            "severity": "error",
+            "human": "All FHIR elements must have a @value or children",
+            "expression": "hasValue() or (children().count() > id.count())",
+            "xpath": "@value|f:*|h:div",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element"
+          }
+        ],
+        "isModifier": false,
+        "isSummary": true,
+        "mapping": [
+          {
+            "identity": "v2",
+            "map": "CX.1 / EI.1"
+          },
+          {
+            "identity": "rim",
+            "map": "II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)"
+          },
+          {
+            "identity": "servd",
+            "map": "./Value"
+          }
+        ]
+      },
+      {
+        "id": "Location.identifier:vTrckS.period",
+        "path": "Location.identifier.period",
+        "short": "Time period when id is/was valid for use",
+        "definition": "Time period during which identifier is/was valid for use.",
+        "min": 0,
+        "max": "1",
+        "base": {
+          "path": "Identifier.period",
+          "min": 0,
+          "max": "1"
+        },
+        "type": [
+          {
+            "code": "Period"
+          }
+        ],
+        "constraint": [
+          {
+            "key": "ele-1",
+            "severity": "error",
+            "human": "All FHIR elements must have a @value or children",
+            "expression": "hasValue() or (children().count() > id.count())",
+            "xpath": "@value|f:*|h:div",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element"
+          }
+        ],
+        "isModifier": false,
+        "isSummary": true,
+        "mapping": [
+          {
+            "identity": "v2",
+            "map": "CX.7 + CX.8"
+          },
+          {
+            "identity": "rim",
+            "map": "Role.effectiveTime or implied by context"
+          },
+          {
+            "identity": "servd",
+            "map": "./StartDate and ./EndDate"
+          }
+        ]
+      },
+      {
+        "id": "Location.identifier:vTrckS.assigner",
         "path": "Location.identifier.assigner",
         "short": "Organization that issued id (may be just text)",
         "definition": "Organization that issued/manages the identifier.",
@@ -2474,6 +2928,21 @@
         ]
       },
       {
+        "id": "Location.identifier",
+        "path": "Location.identifier",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "system"
+            }
+          ],
+          "rules": "open",
+          "description": "Identifier needs at least one VTrckS value"
+        },
+        "min": 1
+      },
+      {
         "id": "Location.identifier.system",
         "path": "Location.identifier.system",
         "min": 1
@@ -2482,6 +2951,19 @@
         "id": "Location.identifier.value",
         "path": "Location.identifier.value",
         "min": 1
+      },
+      {
+        "id": "Location.identifier:vTrckS",
+        "path": "Location.identifier",
+        "sliceName": "vTrckS",
+        "min": 1,
+        "max": "1",
+        "mustSupport": true
+      },
+      {
+        "id": "Location.identifier:vTrckS.system",
+        "path": "Location.identifier.system",
+        "patternUri": "https://cdc.gov/vaccines/programs/vtrcks"
       },
       {
         "id": "Location.name",

--- a/resources/StructureDefinition-vaccine-location.json
+++ b/resources/StructureDefinition-vaccine-location.json
@@ -97,6 +97,27 @@
             "expression": "text.`div`.exists()",
             "xpath": "exists(f:text/h:div)",
             "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+          },
+          {
+            "key": "vaccine-location-1",
+            "severity": "warning",
+            "human": "Location should have a phone and an email",
+            "expression": "telecom.where(system = 'phone').exists() and telecom.where(system = 'url').exists()",
+            "source": "http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-location"
+          },
+          {
+            "key": "vaccine-location-2",
+            "severity": "error",
+            "human": "If a telecom claims to be a phone number, it should only have phone-like characters",
+            "expression": "telecom.where(system = 'phone' and value.contains('@')).empty()",
+            "source": "http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-location"
+          },
+          {
+            "key": "vaccine-location-3",
+            "severity": "error",
+            "human": "If a telecom claims to be a URL, it should only have url-like characters",
+            "expression": "telecom.where(system = 'url').exists() implies telecom.where(system = 'url' and value.matches('\\S')).exists()",
+            "source": "http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-location"
           }
         ],
         "isModifier": false,
@@ -2425,6 +2446,33 @@
   },
   "differential": {
     "element": [
+      {
+        "id": "Location",
+        "path": "Location",
+        "constraint": [
+          {
+            "key": "vaccine-location-1",
+            "severity": "warning",
+            "human": "Location should have a phone and an email",
+            "expression": "telecom.where(system = 'phone').exists() and telecom.where(system = 'url').exists()",
+            "source": "http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-location"
+          },
+          {
+            "key": "vaccine-location-2",
+            "severity": "error",
+            "human": "If a telecom claims to be a phone number, it should only have phone-like characters",
+            "expression": "telecom.where(system = 'phone' and value.contains('@')).empty()",
+            "source": "http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-location"
+          },
+          {
+            "key": "vaccine-location-3",
+            "severity": "error",
+            "human": "If a telecom claims to be a URL, it should only have url-like characters",
+            "expression": "telecom.where(system = 'url').exists() implies telecom.where(system = 'url' and value.matches('\\S')).exists()",
+            "source": "http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-location"
+          }
+        ]
+      },
       {
         "id": "Location.identifier.system",
         "path": "Location.identifier.system",

--- a/resources/StructureDefinition-vaccine-slot.json
+++ b/resources/StructureDefinition-vaccine-slot.json
@@ -102,6 +102,27 @@
             "expression": "text.`div`.exists()",
             "xpath": "exists(f:text/h:div)",
             "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+          },
+          {
+            "key": "vaccine-slot-1",
+            "severity": "warning",
+            "human": "Slot should have a booking link",
+            "expression": "extension.where(url = 'http://fhir-registry.smarthealthit.org/StructureDefinition/booking-deep-link').exists()",
+            "source": "http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-slot"
+          },
+          {
+            "key": "vaccine-slot-2",
+            "severity": "warning",
+            "human": "Slot should have a booking phone number",
+            "expression": "extension.where(url = 'http://fhir-registry.smarthealthit.org/StructureDefinition/booking-phone').exists()",
+            "source": "http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-slot"
+          },
+          {
+            "key": "vaccine-slot-3",
+            "severity": "warning",
+            "human": "Slot should have a capacity if the time frames are longer than an hour",
+            "expression": "extension.where(url = 'http://fhir-registry.smarthealthit.org/StructureDefinition/slot-capacity').exists()",
+            "source": "http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-slot"
           }
         ],
         "isModifier": false,
@@ -1046,6 +1067,33 @@
   },
   "differential": {
     "element": [
+      {
+        "id": "Slot",
+        "path": "Slot",
+        "constraint": [
+          {
+            "key": "vaccine-slot-1",
+            "severity": "warning",
+            "human": "Slot should have a booking link",
+            "expression": "extension.where(url = 'http://fhir-registry.smarthealthit.org/StructureDefinition/booking-deep-link').exists()",
+            "source": "http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-slot"
+          },
+          {
+            "key": "vaccine-slot-2",
+            "severity": "warning",
+            "human": "Slot should have a booking phone number",
+            "expression": "extension.where(url = 'http://fhir-registry.smarthealthit.org/StructureDefinition/booking-phone').exists()",
+            "source": "http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-slot"
+          },
+          {
+            "key": "vaccine-slot-3",
+            "severity": "warning",
+            "human": "Slot should have a capacity if the time frames are longer than an hour",
+            "expression": "extension.where(url = 'http://fhir-registry.smarthealthit.org/StructureDefinition/slot-capacity').exists()",
+            "source": "http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-slot"
+          }
+        ]
+      },
       {
         "id": "Slot.extension",
         "path": "Slot.extension",


### PR DESCRIPTION
This PR adds invariants:

* That suggest that people should have both `phone` and `url` `telecom` elements in `Location`, or else a warning is thrown
* That require that `phone` elements be at least a little bit formatted like a phone number (aka no `@` symbol)
* That require `url` elements to match the FHIR base URL regex (which is `\S`)

Either of the latter two regular expressions can be made more complicated, but for the moment I chose to leave them pretty lenient.