### PR TITLE
Migrate to using a custom CVX Vaccine Product Valueset

### DIFF
--- a/input/fsh/vaccine_location.fsh
+++ b/input/fsh/vaccine_location.fsh
@@ -18,9 +18,10 @@ Id: vaccine-location
 * identifier ^slicing.discriminator.type = #value
 * identifier ^slicing.discriminator.path = "system"
 * identifier ^slicing.rules = #open
-* identifier ^slicing.description = "Identifier needs at least one VTrckS value"
-* identifier contains vTrckS 1..* MS
+* identifier ^slicing.description = "Identifier should have at least one VTrckS value"
+* identifier contains vTrckS 0..* MS
 * identifier[vTrckS].system = "https://cdc.gov/vaccines/programs/vtrcks"
+* obeys vaccine-location-4
 
 ValueSet: SMARTTelecomSystem
 Id: smart-telecom-system
@@ -41,3 +42,8 @@ Invariant: vaccine-location-3
 Description: "If a telecom claims to be a URL, it should only have url-like characters"
 Severity: #error
 Expression: "telecom.where(system = 'url').exists() implies telecom.where(system = 'url' and value.contains(' ')).empty()"
+
+Invariant: vaccine-location-4
+Description: "Location should have at least one VTrckS PIN"
+Severity: #warning
+Expression: "identifier.where(system = 'https://cdc.gov/vaccines/programs/vtrcks').exists()"

--- a/input/fsh/vaccine_schedule.fsh
+++ b/input/fsh/vaccine_schedule.fsh
@@ -23,7 +23,7 @@ Id: vaccine-schedule
 Extension: VaccineProduct
 Id: vaccine-product
 * value[x] only Coding
-* valueCoding from VVS
+* valueCoding from VaccineProductCVX
 
 Extension: VaccineDoseNumber
 Id: vaccine-dose
@@ -51,3 +51,7 @@ Invariant: vaccine-schedule-2
 Description: "Schedule should have an extension with the vaccine-dose URL"
 Severity: #warning
 Expression: "extension.where(url.contains('vaccine-dose')).exists()"
+
+ValueSet: VaccineProductCVX
+Id: vaccine-product-cvx
+* include codes from system http://hl7.org/fhir/sid/cvx

--- a/resources/ImplementationGuide-smart.scheduling.links.json
+++ b/resources/ImplementationGuide-smart.scheduling.links.json
@@ -90,6 +90,13 @@
       },
       {
         "reference": {
+          "reference": "ValueSet/vaccine-product-cvx"
+        },
+        "name": "VaccineProductCVX",
+        "exampleBoolean": false
+      },
+      {
+        "reference": {
           "reference": "ValueSet/vaccine-slot-status"
         },
         "name": "VaccineSlotStatus",

--- a/resources/StructureDefinition-vaccine-location.json
+++ b/resources/StructureDefinition-vaccine-location.json
@@ -118,6 +118,13 @@
             "human": "If a telecom claims to be a URL, it should only have url-like characters",
             "expression": "telecom.where(system = 'url').exists() implies telecom.where(system = 'url' and value.contains(' ')).empty()",
             "source": "http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-location"
+          },
+          {
+            "key": "vaccine-location-4",
+            "severity": "warning",
+            "human": "Location should have at least one VTrckS PIN",
+            "expression": "identifier.where(system = 'https://cdc.gov/vaccines/programs/vtrcks').exists()",
+            "source": "http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-location"
           }
         ],
         "isModifier": false,
@@ -458,12 +465,12 @@
             }
           ],
           "rules": "open",
-          "description": "Identifier needs at least one VTrckS value"
+          "description": "Identifier should have at least one VTrckS value"
         },
         "short": "Unique code or number identifying the location to its users",
         "definition": "Unique code or number identifying the location to its users.",
         "requirements": "Organization label locations in registries, need to keep track of those.",
-        "min": 1,
+        "min": 0,
         "max": "*",
         "base": {
           "path": "Location.identifier",
@@ -905,7 +912,7 @@
         "short": "Unique code or number identifying the location to its users",
         "definition": "Unique code or number identifying the location to its users.",
         "requirements": "Organization label locations in registries, need to keep track of those.",
-        "min": 1,
+        "min": 0,
         "max": "*",
         "base": {
           "path": "Location.identifier",
@@ -2924,6 +2931,13 @@
             "human": "If a telecom claims to be a URL, it should only have url-like characters",
             "expression": "telecom.where(system = 'url').exists() implies telecom.where(system = 'url' and value.contains(' ')).empty()",
             "source": "http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-location"
+          },
+          {
+            "key": "vaccine-location-4",
+            "severity": "warning",
+            "human": "Location should have at least one VTrckS PIN",
+            "expression": "identifier.where(system = 'https://cdc.gov/vaccines/programs/vtrcks').exists()",
+            "source": "http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-location"
           }
         ]
       },
@@ -2938,9 +2952,8 @@
             }
           ],
           "rules": "open",
-          "description": "Identifier needs at least one VTrckS value"
-        },
-        "min": 1
+          "description": "Identifier should have at least one VTrckS value"
+        }
       },
       {
         "id": "Location.identifier.system",
@@ -2956,7 +2969,7 @@
         "id": "Location.identifier:vTrckS",
         "path": "Location.identifier",
         "sliceName": "vTrckS",
-        "min": 1,
+        "min": 0,
         "max": "*",
         "mustSupport": true
       },

--- a/resources/StructureDefinition-vaccine-product.json
+++ b/resources/StructureDefinition-vaccine-product.json
@@ -289,7 +289,7 @@
         "isSummary": false,
         "binding": {
           "strength": "required",
-          "valueSet": "http://hl7.org/fhir/uv/smarthealthcards-vaccination/ValueSet/vaccination-credential-vaccine-value-set"
+          "valueSet": "http://fhir-registry.smarthealthit.org/ValueSet/vaccine-product-cvx"
         },
         "mapping": [
           {
@@ -338,7 +338,7 @@
         "max": "1",
         "binding": {
           "strength": "required",
-          "valueSet": "http://hl7.org/fhir/uv/smarthealthcards-vaccination/ValueSet/vaccination-credential-vaccine-value-set"
+          "valueSet": "http://fhir-registry.smarthealthit.org/ValueSet/vaccine-product-cvx"
         }
       }
     ]

--- a/resources/ValueSet-vaccine-product-cvx.json
+++ b/resources/ValueSet-vaccine-product-cvx.json
@@ -1,0 +1,15 @@
+{
+  "resourceType": "ValueSet",
+  "status": "active",
+  "name": "VaccineProductCVX",
+  "id": "vaccine-product-cvx",
+  "version": "0.1.0",
+  "url": "http://fhir-registry.smarthealthit.org/ValueSet/vaccine-product-cvx",
+  "compose": {
+    "include": [
+      {
+        "system": "http://hl7.org/fhir/sid/cvx"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
To avoid a dependency on an external ValueSet, this PR migrates to using a custom ValueSet for vaccine products, which includes all codes from the CVX CodeSystem.﻿
